### PR TITLE
No-changes merge of the percona fork

### DIFF
--- a/build.c
+++ b/build.c
@@ -255,7 +255,7 @@ mk_order(long index, order_t *o, long upd_num)
 		RANDOM(o->lineorders[lcnt].tax, L_TAX_MIN, L_TAX_MAX, L_TAX_SD);
 
 		strcpy(o->lineorders[lcnt].orderdate,o->odate);
-
+		//printf("l1 :%d, l2: %d\n",sizeof(o->lineorders[lcnt].opriority), sizeof(o->opriority));
 		strcpy(o->lineorders[lcnt].opriority,o->opriority);
 		o->lineorders[lcnt].ship_priority = o->spriority;
 

--- a/dsstypes.h
+++ b/dsstypes.h
@@ -56,7 +56,7 @@ typedef struct
     long            partkey;
     long            suppkey;
     char            orderdate[DATE_LEN];
-    char            opriority[MAXAGG_LEN + 1];
+    char            opriority[O_PRIO_SD + 1];
     long            ship_priority;
     long             quantity;
     long           extended_price;
@@ -98,7 +98,8 @@ typedef struct
     long            custkey;
     int             totalprice;
     char            odate[DATE_LEN];
-    char            opriority[MAXAGG_LEN + 1];
+    char            opriority[O_PRIO_SD + 1];
+    //char            opriority[MAXAGG_LEN + 1];
     char            clerk[O_CLRK_LEN + 1];
     int             spriority;
     long            lines;

--- a/makefile
+++ b/makefile
@@ -9,12 +9,12 @@ CC      = gcc
 #                                  SGI, SUN, U2200, VMS, LINUX
 # Current values for WORKLOAD are:  SSBM, TPCH, TPCR
 DATABASE=DB2 
-MACHINE =MAC
+MACHINE =LINUX
 WORKLOAD =SSBM 
 #
 # add -EDTERABYTE if orderkey will execeed 32 bits (SF >= 300)
 # and make the appropriate change in gen_schema() of runit.sh
-CFLAGS	= -O -DDBNAME=\"dss\" -D$(MACHINE) -D$(DATABASE) -D$(WORKLOAD)
+CFLAGS	= -g -O -DDBNAME=\"dss\" -D$(MACHINE) -D$(DATABASE) -D$(WORKLOAD)
 LDFLAGS = -O
 # The OBJ,EXE and LIB macros will need to be changed for compilation under
 #  Windows NT


### PR DESCRIPTION
I've already integrated the relevant changes in the Percona fork; let's mark it merged.

BTW: No need to switch from `MAX_AGG_LENGTH` to something else in `dsstypes.h` like Percona did; see issue #6 for more details. 