### PR TITLE
Segmentation fault fix

### DIFF
--- a/rnd.c
+++ b/rnd.c
@@ -25,6 +25,8 @@ void
 dss_random(long *tgt, long lower, long upper, long stream)
 {
 	*tgt = UnifInt((long)lower, (long)upper, (long)stream);
+	if (stream < 0 || stream > MAX_STREAM)
+		stream = 0;
 	Seed[stream].usage += 1;
 
 	return;


### PR DESCRIPTION
The current version of ssb-dbgen is crashing with a segmentation fault if it is built using `clang` with enabled optimizations under Linux and if it is built using either `clang` or `gcc` with enabled optimizations under OS X.

During debugging I found inconsistency between `dss_random` and `UnifInt` in rnd.c.
`UnifInt` contract specifies that 
> `nStream` is the random number stream. Stream 0 is used if `nStream` is not in the range 0..`MAX_STREAM`.

But `dss_random` ignore it and modify `Seed[stream]` with unchanged `stream`, where `stream` is an arbitrary `long` (previously passed to `UnifInt` as a third parameter).
Probably, it could be better to make `nStream`(the third parameter of `UnifInt`) a pointer, but it requires a bunch of changes in the whole project, so I decide to simply add the corresponding condition checking to the `dss_random`. 