### PR TITLE
Ci for Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,6 +97,13 @@ matrix:
             - clang-6.0
       env:
         - MATRIX_EVAL="export CC=clang-6.0"
+    
+    - os: windows
+      addons:
+        chocolatey:
+            packages:
+                visualstudio2017buildtools
+      script: cmake -G "Visual Studio 15 2017" . && cmake --build .
 
 before_install:
 - eval "${MATRIX_EVAL}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,5 +105,12 @@ matrix:
                 visualstudio2017buildtools
       script: cmake -G "Visual Studio 15 2017" . && cmake --build .
 
+    - os: windows
+      addons:
+        chocolatey:
+            packages:
+                mingw
+      script: cmake -G "MinGW Makefiles" -DCMAKE_SH="CMAKE_SH-NOTFOUND" . && cmake --build .
+
 before_install:
 - eval "${MATRIX_EVAL}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,8 +69,11 @@ add_executable(qgen
 )
 
 # Link against the C math library (libm)
-target_link_libraries(dbgen m)
-target_link_libraries(qgen m)
+find_library(HAVE_LIBM m)
+if (HAVE_LIBM)
+	target_link_libraries(dbgen m)
+	target_link_libraries(qgen m)
+endif()
 
 set_property(
 	TARGET dbgen qgen
@@ -99,5 +102,5 @@ elseif ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
 elseif ("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
     set_property(TARGET dbgen qgen APPEND PROPERTY COMPILE_OPTIONS "/W3")
     set_property(TARGET dbgen qgen APPEND PROPERTY COMPILE_DEFINITIONS _CRT_NONSTDC_NO_DEPRECATE _CRT_SECURE_NO_WARNINGS)
-endif ("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+endif()
 


### PR DESCRIPTION
* Windows environments with Visual Studio and MinGW compilers were added to Travis CI config
* There is no `libm` on Windows, so CMakeLists.txt was updated to link with it only if it exists