### PR TITLE
Add support for generating dates in format YYYY-MM-DD for easier use in MariaDB / MySQL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ set(WORKLOAD SSB CACHE STRING "Choice of benchmark / query workload (\"WORKLOAD\
 set_property(CACHE WORKLOAD PROPERTY STRINGS TPCH SSB)
 
 set(EOL_HANDLING OFF CACHE BOOL "Skip separator after the last field in generated lines?")
+set(YMD_DATE OFF CACHE BOOL "Override date format values to yyyy-mm-dd?")
 
 check_type_size("long long"        SIZEOF_LONG_LONG)
 check_type_size("long"             SIZEOF_LONG)
@@ -86,6 +87,9 @@ set_property(
 
 if (EOL_HANDLING)
 	set_property( TARGET dbgen qgen APPEND PROPERTY COMPILE_DEFINITIONS EOL_HANDLING)
+endif()
+if (YMD_DATE)
+	set_property( TARGET dbgen qgen APPEND PROPERTY COMPILE_DEFINITIONS YMD_DATE)
 endif()
 
 set_property(TARGET dbgen qgen APPEND PROPERTY C_STANDARD 99)

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -7,6 +7,7 @@
  *   SEPARATOR         -- character used to separate fields in flat files
  *   STDLIB_HAS_GETOPT -- to prevent confilcts with gloabal getopt() 
  *   MDY_DATE          -- generate dates as MM-DD-YY
+ *   YMD_DATE          -- generate dates as YYYY-MM-DD
  *   WIN32             -- support for WindowsNT
  *   DSS_HUGE          -- 64 bit data type
  *   HUGE_FORMAT       -- printf string for 64 bit data type

--- a/src/dss.h
+++ b/src/dss.h
@@ -522,12 +522,21 @@ int dbg_print(int dt, FILE *tgt, void *data, int len, int eol);
 
 
 #ifdef SSB
+#ifdef YMD_DATE
+#define  PR_DATE(tgt, yr, mn, dy) { \
+	int yr_  = yr; \
+	int mn_  = mn; \
+	int dy_  = dy; \
+  snprintf(tgt, 2+1+2+1+4+1, "19%02d-%02d-%02d",yr_, mn_, dy_); \
+}
+#else
 #define  PR_DATE(tgt, yr, mn, dy) { \
 	int yr_  = yr; \
 	int mn_  = mn; \
 	int dy_  = dy; \
 	snprintf(tgt, 4+2+2+1, "19%02d%02d%02d", yr_, mn_, dy_); \
 }
+#endif
 #else
 #ifdef MDY_DATE
 #define  PR_DATE(tgt, yr, mn, dy) { \

--- a/src/print.c
+++ b/src/print.c
@@ -660,7 +660,13 @@ int pr_date(date_t *d, int mode){
 	d_fp = print_prep(DATE, 0);
 
     PR_STRT(d_fp);
+#ifdef YMD_DATE
+    char ymd_date[D_DATE_LEN];
+    PR_DATE(ymd_date, d->year-1900, d->monthnuminyear, d->daynuminmonth);
+    PR_STR(d_fp, ymd_date, D_DATE_LEN);
+#else
     PR_INT(d_fp, d->datekey);
+#endif
     PR_STR(d_fp, d->date,D_DATE_LEN);
     PR_STR(d_fp, d->dayofweek,D_DAYWEEK_LEN);
     PR_STR(d_fp, d->month,D_MONTH_LEN);


### PR DESCRIPTION
This adds a cmake flag and #define YMD_DATES that will generate dates in the format YYYY-MM-DD making the files (in conjunction with EOL_HANDLING) directly consumable by MariaDB ColumnStore cpimport when loading to a Date column.  This will also make the files easier to consume for other MariaDB and MySQL tools.