### PR TITLE
Add support for generating dates in format YYYY-MM-DD for easier use in MariaDB / MySQL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ set(WORKLOAD SSB CACHE STRING "Choice of benchmark / query workload (\"WORKLOAD\
 set_property(CACHE WORKLOAD PROPERTY STRINGS TPCH SSB)
 
 set(EOL_HANDLING OFF CACHE BOOL "Skip separator after the last field in generated lines?")
+set(YMD_DATE OFF CACHE BOOL "Override date format values to yyyy-mm-dd?")
 
 check_type_size("long long" SIZEOF_LONG_LONG)
 check_type_size("long" SIZEOF_LONG)
@@ -158,6 +159,9 @@ set_property(
 
 if (EOL_HANDLING)
 	set_property( TARGET dbgen qgen APPEND PROPERTY COMPILE_DEFINITIONS EOL_HANDLING)
+endif()
+if (YMD_DATE)
+	set_property( TARGET dbgen qgen APPEND PROPERTY COMPILE_DEFINITIONS YMD_DATE)
 endif()
 
 set_property(TARGET dbgen qgen APPEND PROPERTY C_STANDARD 99)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ set(WORKLOAD SSB CACHE STRING "Choice of benchmark / query workload (\"WORKLOAD\
 set_property(CACHE WORKLOAD PROPERTY STRINGS TPCH SSB)
 
 set(EOL_HANDLING OFF CACHE BOOL "Skip separator after the last field in generated lines?")
-set(YMD_DATE OFF CACHE BOOL "Override date format values to yyyy-mm-dd?")
+set(YMD_DASH_DATE OFF CACHE BOOL "If set generates date values using format yyyy-mm-dd instaead of the default yyyymmdd")
 
 check_type_size("long long" SIZEOF_LONG_LONG)
 check_type_size("long" SIZEOF_LONG)
@@ -160,8 +160,8 @@ set_property(
 if (EOL_HANDLING)
 	set_property( TARGET dbgen qgen APPEND PROPERTY COMPILE_DEFINITIONS EOL_HANDLING)
 endif()
-if (YMD_DATE)
-	set_property( TARGET dbgen qgen APPEND PROPERTY COMPILE_DEFINITIONS YMD_DATE)
+if (YMD_DASH_DATE)
+	set_property( TARGET dbgen qgen APPEND PROPERTY COMPILE_DEFINITIONS YMD_DASH_DATE)
 endif()
 
 set_property(TARGET dbgen qgen APPEND PROPERTY C_STANDARD 99)

--- a/src/build.c
+++ b/src/build.c
@@ -702,9 +702,6 @@ mk_date(long index,date_t *d)
     strncpy(d->month,month_names[d->monthnuminyear-1],D_MONTH_LEN+1);
 #if __GNUC__ >= 8
 #pragma GCC diagnostic pop
-#else
-    strncpy(d->dayofweek, weekday_names[d->daynuminweek-1],D_DAYWEEK_LEN+1);
-    strncpy(d->month,month_names[d->monthnuminyear-1],D_MONTH_LEN+1);
 #endif
     d->year=(long)localTime->tm_year + 1900;
     d->daynuminmonth=(long)localTime->tm_mday;

--- a/src/build.c
+++ b/src/build.c
@@ -702,6 +702,9 @@ mk_date(long index,date_t *d)
     strncpy(d->month,month_names[d->monthnuminyear-1],D_MONTH_LEN+1);
 #if __GNUC__ >= 8
 #pragma GCC diagnostic pop
+#else
+    strncpy(d->dayofweek, weekday_names[d->daynuminweek-1],D_DAYWEEK_LEN+1);
+    strncpy(d->month,month_names[d->monthnuminyear-1],D_MONTH_LEN+1);
 #endif
     d->year=(long)localTime->tm_year + 1900;
     d->daynuminmonth=(long)localTime->tm_mday;

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -6,6 +6,7 @@
  * The following #defines will effect the code:
  *   SEPARATOR         -- character used to separate fields in flat files
  *   MDY_DATE          -- generate dates as MM-DD-YY
+ *   YMD_DATE          -- generate dates as YYYY-MM-DD
  *   WIN32             -- support for WindowsNT
  *   DSS_HUGE          -- 64 bit data type
  *   HUGE_FORMAT       -- printf string for 64 bit data type

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -5,8 +5,7 @@
  * 
  * The following #defines will effect the code:
  *   SEPARATOR         -- character used to separate fields in flat files
- *   MDY_DATE          -- generate dates as MM-DD-YY
- *   YMD_DATE          -- generate dates as YYYY-MM-DD
+ *   YMD_DASH_DATE     -- generate dates as YYYY-MM-DD
  *   WIN32             -- support for WindowsNT
  *   DSS_HUGE          -- 64 bit data type
  *   HUGE_FORMAT       -- printf string for 64 bit data type

--- a/src/dss.h
+++ b/src/dss.h
@@ -522,12 +522,21 @@ int dbg_print(int dt, FILE *tgt, void *data, int len, int eol);
 
 
 #ifdef SSB
+#ifdef YMD_DATE
+#define  PR_DATE(tgt, yr, mn, dy) { \
+	int yr_  = yr; \
+	int mn_  = mn; \
+	int dy_  = dy; \
+  snprintf(tgt, 2+1+2+1+4+1, "19%02d-%02d-%02d",yr_, mn_, dy_); \
+}
+#else
 #define  PR_DATE(tgt, yr, mn, dy) { \
 	int yr_  = yr; \
 	int mn_  = mn; \
 	int dy_  = dy; \
 	snprintf(tgt, 4+2+2+1, "19%02d%02d%02d", yr_, mn_, dy_); \
 }
+#endif
 #else
 #ifdef MDY_DATE
 #define  PR_DATE(tgt, yr, mn, dy) { \

--- a/src/dss.h
+++ b/src/dss.h
@@ -522,7 +522,7 @@ int dbg_print(int dt, FILE *tgt, void *data, int len, int eol);
 
 
 #ifdef SSB
-#ifdef YMD_DATE
+#ifdef YMD_DASH_DATE
 #define  PR_DATE(tgt, yr, mn, dy) { \
 	int yr_  = yr; \
 	int mn_  = mn; \
@@ -538,22 +538,12 @@ int dbg_print(int dt, FILE *tgt, void *data, int len, int eol);
 }
 #endif
 #else
-#ifdef MDY_DATE
-#define  PR_DATE(tgt, yr, mn, dy) { \
-	int yr_  = yr; \
-	int mn_  = mn; \
-	int dy_  = dy; \
-	snprintf(tgt, 2+1+2+1+4+1, "%02d-%02d-19%02d", mn_, dy_, yr_) \
-}
-
-#else
 #define  PR_DATE(tgt, yr, mn, dy) { \
 	int yr_  = yr; \
 	int mn_  = mn; \
 	int dy_  = dy; \
 	snprintf(tgt, 2+1+2+1+4+1, "%02d-%02d-19%02d", yr_, mn_, dy_) \
 }
-#endif /* DATE_FORMAT */
 #endif
 
 /*

--- a/src/print.c
+++ b/src/print.c
@@ -656,7 +656,13 @@ int pr_date(date_t *d, int mode){
 	d_fp = print_prep(DATE, 0);
 
     PR_STRT(d_fp);
+ #ifdef YMD_DATE
+    char ymd_date[D_DATE_LEN];
+    PR_DATE(ymd_date, d->year-1900, d->monthnuminyear, d->daynuminmonth);
+    PR_STR(d_fp, ymd_date, D_DATE_LEN);
+#else   
     PR_INT(d_fp, d->datekey);
+#endif
     PR_STR(d_fp, d->date,D_DATE_LEN);
     PR_STR(d_fp, d->dayofweek,D_DAYWEEK_LEN);
     PR_STR(d_fp, d->month,D_MONTH_LEN);

--- a/src/print.c
+++ b/src/print.c
@@ -656,13 +656,9 @@ int pr_date(date_t *d, int mode){
 	d_fp = print_prep(DATE, 0);
 
     PR_STRT(d_fp);
- #ifdef YMD_DATE
-    char ymd_date[D_DATE_LEN];
+    char ymd_date[DATE_LEN];
     PR_DATE(ymd_date, d->year-1900, d->monthnuminyear, d->daynuminmonth);
-    PR_STR(d_fp, ymd_date, D_DATE_LEN);
-#else   
-    PR_INT(d_fp, d->datekey);
-#endif
+    PR_STR(d_fp, ymd_date, DATE_LEN);
     PR_STR(d_fp, d->date,D_DATE_LEN);
     PR_STR(d_fp, d->dayofweek,D_DAYWEEK_LEN);
     PR_STR(d_fp, d->month,D_MONTH_LEN);


### PR DESCRIPTION
Resubmitting against additional_fixes branch.

Add #define and cmake property YMD_DATE that will generate date 
values in format YYYY-MM-DD allowing use of date columns and direct
 use of files with MariaDB ColumnStore cpimport. This will also be
 of use for MySQL / MariaDB load data infile and similar tools.

Also fix an issue with invalid date display values in date.tbl using gcc < 8